### PR TITLE
feat: make color constants case-insensitive

### DIFF
--- a/lib/BoardcastHexBoard.test.ts
+++ b/lib/BoardcastHexBoard.test.ts
@@ -1040,9 +1040,18 @@ describe('BoardcastHexBoard - Visual Methods', () => {
       it('should resolve direct color constants to hex colors', () => {
         board.highlight(0, 0, 'BLUE')
         forceRender()
-        
+
         const hexElement = svg.querySelector('[fill="#4FC3F7"]')
         expect(hexElement).toBeTruthy()
+      })
+
+      it('should resolve color constants regardless of case', () => {
+        board.highlight(0, 0, 'blue')
+        board.highlight(1, 0, 'Colors.red')
+        forceRender()
+
+        expect(svg.querySelector('[fill="#4FC3F7"]')).toBeTruthy()
+        expect(svg.querySelector('[fill="#FF6B6B"]')).toBeTruthy()
       })
 
       it('should resolve semantic color constants', () => {

--- a/lib/BoardcastHexBoard.ts
+++ b/lib/BoardcastHexBoard.ts
@@ -41,21 +41,25 @@ export class BoardcastHexBoard {
   /**
    * Resolves color constants (e.g., "Colors.BLUE") to hex color codes.
    * If the input is already a hex color or not a color constant, returns it unchanged.
-   */
+  */
   private resolveColor(colorInput: string): string {
-    // Check if it's a Colors constant (e.g., "Colors.BLUE", "BLUE")
-    if (colorInput.startsWith('Colors.')) {
-      const colorName = colorInput.slice(7) as keyof typeof Colors;
-      return Colors[colorName] || colorInput;
+    const input = colorInput.trim();
+
+    // Check if it's a Colors constant (e.g., "Colors.BLUE") - case insensitive
+    const lower = input.toLowerCase();
+    if (lower.startsWith('colors.')) {
+      const colorName = input.slice(7).trim().toUpperCase() as keyof typeof Colors;
+      return Colors[colorName] || input;
     }
-    
-    // Check if it's just the color name (e.g., "BLUE")
-    if (colorInput in Colors) {
-      return Colors[colorInput as keyof typeof Colors];
+
+    // Check if it's just the color name (e.g., "BLUE") - case insensitive
+    const upper = input.toUpperCase();
+    if (upper in Colors) {
+      return Colors[upper as keyof typeof Colors];
     }
-    
+
     // Otherwise, assume it's already a hex color or valid CSS color
-    return colorInput;
+    return input;
   }
 
   private axialToPixel(q: number, r: number): { x: number; y: number } {


### PR DESCRIPTION
## Summary
- allow `BoardcastHexBoard` to accept color constant names regardless of case
- add tests verifying case-insensitive color resolution

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ac314767fc8322bf724b16c73f5845